### PR TITLE
Changed node-alpine version 

### DIFF
--- a/astro/Dockerfile
+++ b/astro/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine as base
+FROM node:20-alpine3.18 as base
 WORKDIR /base
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile

--- a/payload/Dockerfile
+++ b/payload/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts as base
+FROM node:18-alpine as base
 WORKDIR /base
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile

--- a/payload/Dockerfile
+++ b/payload/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as base
+FROM node:18.8-alpine as base
 WORKDIR /base
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile


### PR DESCRIPTION
Changed it to node:20-alpine3.18 because of sharp installation errors:

`#11 69.29 error /base/node_modules/sharp: Command failed.
#11 69.29 Exit code: 1
#11 69.29 Command: (node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)
#11 69.29 Arguments: 
#11 69.29 Directory: /base/node_modules/sharp
#11 69.29 Output:
#11 69.29 sharp: Installation error: Invalid Version: 1.2.4_git20230717
#11 69.29 sharp: Please see https://sharp.pixelplumbing.com/install for required dependencies
#11 69.29 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.`